### PR TITLE
Init deregisters commands

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -72,6 +72,10 @@ registered (default of 16).
 console library (default of 128).
 * `CONSOLE_PROMPT` - The string displayed to prompt for console input (default
 of "> ").
+* `CONSOLE_RETURN_KEY` - Specifies the character sequence for the console
+return key (default is '\n').
+* `CONSOLE_NEWLINE` - Defines the character sequence for console newline
+(default is '\n').
 * `CONSOLE_BUFFER_ATTRIBUTES` - Extra GCC attributes to add to the internal
 buffers used by the console library (default of none). As an example, this can
 be used in cases where these buffers should be placed in a different linker

--- a/console/README.md
+++ b/console/README.md
@@ -49,12 +49,16 @@ argument (can only be used for the last argument).
 argument (can only be used for the last argument).
 
 The `CONSOLE_COMMAND_DEF()` macro will forward declare a handler for the
-console command with the following prototype:
-`static void <CMD>_command_handler(const <CMD>_args_t* args);`. This function
-will be called whenver the console command is invoked, with the `args` argument
-containing the validated, parsed, and appropriately typed (`intptr_t` /
-`const char*`) arguments. For optional arguments, a default value of `-1` /
-`NULL` will be set for integer / string arguments respectively.
+console command with one of the following prototypes depending on whether or not
+the command has arguments:
+* `static void <CMD>_command_handler(const <CMD>_args_t* args);`
+* `static void <CMD>_command_handler(void);`
+
+This function will be called whenever the console command is invoked, with the
+`args` argument (if applicable) containing the validated, parsed, and
+appropriately typed (`intptr_t` / `const char*`) arguments. For optional
+arguments, a default value of `-1` / `NULL` will be set for integer / string
+arguments respectively.
 
 ### Initializing the Library and Registering Commands
 
@@ -102,8 +106,10 @@ These tests are built using
 
 ## Example
 
-```
+```c
 #include "anchor/console/console.h"
+
+CONSOLE_COMMAND_DEF(hello_world, "Prints a greeting");
 
 CONSOLE_COMMAND_DEF(gpio_set, "Sets a GPIO pin",
     CONSOLE_STR_ARG_DEF(port, "The port <A,B,C>"),
@@ -116,12 +122,16 @@ CONSOLE_COMMAND_DEF(gpio_get, "Gets a GPIO pin value",
     CONSOLE_INT_ARG_DEF(pin, "The pin <0-15>")
 );
 
+static void hello_world_command_handler(void) {
+    printf("Hello World\n");
+}
+
 static void gpio_set_command_handler(const gpio_set_args_t* args) {
     gpio_write(args->port, args->pin, args->value);
 }
 
 static void gpio_get_command_handler(const gpio_get_args_t* args) {
-    printf("value=%d", gpio_read(args->port, args->pin));
+    printf("value=%d\n", gpio_read(args->port, args->pin));
 }
 
 void main(void) {

--- a/console/README.md
+++ b/console/README.md
@@ -80,9 +80,9 @@ section.
 This can be disabled to save code space. Disabling this will also remove the
 `desc` attribute of commands and arguments.
 * `CONSOLE_FULL_CONTROL` - Enables more advanced line control features such as
-backspace and CTRL-C (default of 1). Also enables the `console_print_line()`
-function. This setting also results in the console echo'ing back any valid
-characters it receives.
+backspace, left and right arrow keys, and CTRL-C (default of 1). Also enables
+the `console_print_line()` function. This setting also results in the console
+echo'ing back any valid characters it receives.
 * `CONSOLE_TAB_COMPLETE` - Enables tab-completion of console commands (default
 of 1). This depends on `CONSOLE_FULL_CONTROL` being enabled.
 * `CONSOLE_HISTORY` - Enables history accessible via up/down arrow keys with

--- a/console/include/anchor/console/console.h
+++ b/console/include/anchor/console/console.h
@@ -11,6 +11,7 @@
 
 // Generic command handler type which is used internally by the console library
 typedef void(*console_command_handler_t)(const void*);
+typedef void(*console_command_handler_no_args_t)(void);
 #if CONSOLE_TAB_COMPLETE
 // Handler used for tab-completion
 typedef const char*(*console_tab_complete_iterator_t)(bool);
@@ -44,7 +45,10 @@ typedef struct {
     const char* desc;
 #endif
     // The command handler
-    console_command_handler_t handler;
+    union {
+        console_command_handler_t handler;
+        console_command_handler_no_args_t handler_no_args;
+    };
 #if CONSOLE_TAB_COMPLETE
     // The auto complete iterator
     console_tab_complete_iterator_t tab_complete_iter;

--- a/console/include/anchor/console/console_config.h
+++ b/console/include/anchor/console/console_config.h
@@ -14,6 +14,14 @@
 #define CONSOLE_PROMPT "> "
 #endif
 
+#ifndef CONSOLE_RETURN_KEY
+#define CONSOLE_RETURN_KEY '\n'
+#endif
+
+#ifndef CONSOLE_NEWLINE
+#define CONSOLE_NEWLINE "\n"
+#endif
+
 #ifndef CONSOLE_BUFFER_ATTRIBUTES
 #define CONSOLE_BUFFER_ATTRIBUTES
 #endif

--- a/console/include/anchor/console/console_private_helpers.h
+++ b/console/include/anchor/console/console_private_helpers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "anchor/console/console_config.h"
+
 #if defined(__GNUC__) || defined(__TI_COMPILER_VERSION__)
 
 // The _CONSOLE_NUM_ARGS(...) macro returns the number of arguments passed to it (0-10)
@@ -11,7 +13,7 @@ _Static_assert(_CONSOLE_NUM_ARGS() == 0, "_CONSOLE_NUM_ARGS() != 0");
 _Static_assert(_CONSOLE_NUM_ARGS(1) == 1, "_CONSOLE_NUM_ARGS(1) != 1");
 _Static_assert(_CONSOLE_NUM_ARGS(1,2,3,4,5,6,7,8,9,10) == 10, "_CONSOLE_NUM_ARGS(<10_args>) != 10");
 
-// General helper macro for concatentating two tokens
+// General helper macro for concatenating two tokens
 #define _CONSOLE_CONCAT(A, B) _CONSOLE_CONCAT2(A, B)
 #define _CONSOLE_CONCAT2(A, B) A ## B
 
@@ -30,17 +32,72 @@ _Static_assert(_CONSOLE_NUM_ARGS(1,2,3,4,5,6,7,8,9,10) == 10, "_CONSOLE_NUM_ARGS
 #define _CONSOLE_MAP_9(X,_1,_2,_3,_4,_5,_6,_7,_8,_9) X(_1) X(_2) X(_3) X(_4) X(_5) X(_6) X(_7) X(_8) X(_9)
 #define _CONSOLE_MAP_10(X,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10) X(_1) X(_2) X(_3) X(_4) X(_5) X(_6) X(_7) X(_8) X(_9) X(_10)
 
-// Helper macros for defining console_arg_def_t instances.
+// Helper macros for defining console commands and their arguments
+#define _CONSOLE_COMMAND_DEF(CMD, DESC, ...) \
+    _CONSOLE_COMMAND_ARGS_AND_HANDLER(CMD, ##__VA_ARGS__) \
+    static void CMD##_command_handler(const CMD##_args_t* args); \
+    _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_DEFAULT_DEF(CMD) \
+    static const console_command_def_t _##CMD##_DEF = { \
+        .name = #CMD, \
+        _CONSOLE_COMMAND_DEF_DESC_FIELD(DESC) \
+        .handler = (console_command_handler_t)CMD##_command_handler, \
+        _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD) \
+        .args = _##CMD##_ARGS_DEF, \
+        .num_args = sizeof(_##CMD##_ARGS_DEF) / sizeof(console_arg_def_t), \
+        .args_ptr = _##CMD##_ARGS, \
+    }; \
+    static const console_command_def_t* const CMD = &_##CMD##_DEF
+#define _CONSOLE_COMMAND_DEF_WITH_TAB_COMPLETION(CMD, DESC, ...) \
+    _CONSOLE_COMMAND_ARGS_AND_HANDLER(CMD, ##__VA_ARGS__) \
+    static void CMD##_command_handler(const CMD##_args_t* args); \
+    _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_PROTOTYPE(CMD) \
+    static const console_command_def_t _##CMD##_DEF = { \
+        .name = #CMD, \
+        _CONSOLE_COMMAND_DEF_DESC_FIELD(DESC) \
+        .handler = (console_command_handler_t)CMD##_command_handler, \
+        _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD) \
+        .args = _##CMD##_ARGS_DEF, \
+        .num_args = sizeof(_##CMD##_ARGS_DEF) / sizeof(console_arg_def_t), \
+        .args_ptr = _##CMD##_ARGS, \
+    }; \
+    static const console_command_def_t* const CMD = &_##CMD##_DEF
+#if CONSOLE_HELP_COMMAND
+#define _CONSOLE_COMMAND_DEF_DESC_FIELD(DESC) .desc = DESC,
+#else
+#define _CONSOLE_COMMAND_DEF_DESC_FIELD(DESC)
+#endif
+#if CONSOLE_TAB_COMPLETE
+#define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_DEFAULT_DEF(CMD) \
+    static const console_tab_complete_iterator_t CMD##_tab_complete_iterator = NULL;
+#define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_PROTOTYPE(CMD) \
+    static const char* CMD##_tab_complete_iterator(bool start);
+#define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD) .tab_complete_iter = CMD##_tab_complete_iterator,
+#else
+#define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_DEFAULT_DEF(CMD)
+#define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_PROTOTYPE(CMD)
+#define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD)
+#endif
+#define _CONSOLE_COMMAND_ARGS_AND_HANDLER(CMD, ...) \
+    typedef struct { \
+        _CONSOLE_MAP(_CONSOLE_ARG_TYPE_HELPER, ##__VA_ARGS__) \
+        const void* const __dummy; /* dummy entry so the struct isn't empty */ \
+    } CMD##_args_t; \
+    _Static_assert(sizeof(CMD##_args_t) == (_CONSOLE_NUM_ARGS(__VA_ARGS__) + 1) * sizeof(void *), \
+        "Compiler created *_args_t struct of unexpected size"); \
+    static const console_arg_def_t _##CMD##_ARGS_DEF[] = { \
+        _CONSOLE_MAP(_CONSOLE_ARG_DEF_HELPER, ##__VA_ARGS__) \
+    }; \
+    static void* _##CMD##_ARGS[_CONSOLE_NUM_ARGS(__VA_ARGS__)];
 #define _CONSOLE_ARG_DEF_HELPER(...) _CONSOLE_ARG_DEF_HELPER2 __VA_ARGS__
-#define _CONSOLE_ARG_DEF_HELPER2(NAME, DESC, ENUM_TYPE, IS_OPTIONAL, C_TYPE) \
-    { .name = #NAME, .type = ENUM_TYPE, .is_optional = IS_OPTIONAL },
-#define _CONSOLE_ARG_DEF_WITH_DESC_HELPER(...) _CONSOLE_ARG_DEF_WITH_DESC_HELPER2 __VA_ARGS__
-#define _CONSOLE_ARG_DEF_WITH_DESC_HELPER2(NAME, DESC, ENUM_TYPE, IS_OPTIONAL, C_TYPE) \
+#if CONSOLE_HELP_COMMAND
+#define _CONSOLE_ARG_DEF_HELPER2(NAME, ENUM_TYPE, IS_OPTIONAL, C_TYPE, DESC) \
     { .name = #NAME, .desc = DESC, .type = ENUM_TYPE, .is_optional = IS_OPTIONAL },
-
-// Helper macros for defining command *_arg_t types.
-#define _CONSOLE_ARG_TYPE_WITH_DESC_HELPER(...) _CONSOLE_ARG_TYPE_WITH_DESC_HELPER2 __VA_ARGS__
-#define _CONSOLE_ARG_TYPE_WITH_DESC_HELPER2(NAME, DESC, ENUM_TYPE, IS_OPTIONAL, C_TYPE) \
+#else
+#define _CONSOLE_ARG_DEF_HELPER2(NAME, ENUM_TYPE, IS_OPTIONAL, C_TYPE) \
+    { .name = #NAME, .type = ENUM_TYPE, .is_optional = IS_OPTIONAL },
+#endif
+#define _CONSOLE_ARG_TYPE_HELPER(...) _CONSOLE_ARG_TYPE_HELPER2 __VA_ARGS__
+#define _CONSOLE_ARG_TYPE_HELPER2(NAME, ENUM_TYPE, IS_OPTIONAL, C_TYPE, ...) \
     C_TYPE NAME;
 
 #else // !defined(__GNUC__)

--- a/console/include/anchor/console/console_private_helpers.h
+++ b/console/include/anchor/console/console_private_helpers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__TI_COMPILER_VERSION__)
 
 // The _CONSOLE_NUM_ARGS(...) macro returns the number of arguments passed to it (0-10)
 #define _CONSOLE_NUM_ARGS(...) _CONSOLE_NUM_ARGS_HELPER1(_, ##__VA_ARGS__, _CONSOLE_NUM_ARGS_SEQ())

--- a/console/include/anchor/console/console_private_helpers.h
+++ b/console/include/anchor/console/console_private_helpers.h
@@ -2,7 +2,9 @@
 
 #include "anchor/console/console_config.h"
 
-#if defined(__GNUC__) || defined(__TI_COMPILER_VERSION__)
+#if !defined(__GNUC__) && !defined(__TI_COMPILER_VERSION__)
+#error "Unsupported toolchain"
+#endif
 
 // The _CONSOLE_NUM_ARGS(...) macro returns the number of arguments passed to it (0-10)
 #define _CONSOLE_NUM_ARGS(...) _CONSOLE_NUM_ARGS_HELPER1(_, ##__VA_ARGS__, _CONSOLE_NUM_ARGS_SEQ())
@@ -32,15 +34,35 @@ _Static_assert(_CONSOLE_NUM_ARGS(1,2,3,4,5,6,7,8,9,10) == 10, "_CONSOLE_NUM_ARGS
 #define _CONSOLE_MAP_9(X,_1,_2,_3,_4,_5,_6,_7,_8,_9) X(_1) X(_2) X(_3) X(_4) X(_5) X(_6) X(_7) X(_8) X(_9)
 #define _CONSOLE_MAP_10(X,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10) X(_1) X(_2) X(_3) X(_4) X(_5) X(_6) X(_7) X(_8) X(_9) X(_10)
 
+// Helper macros for defining things differently if the command has args or not
+#define _CONSOLE_IF_ARGS(VAL, ...) _CONSOLE_IF_ELSE_NO_ARGS(, VAL, ##__VA_ARGS__)
+#define _CONSOLE_IF_NO_ARGS(VAL, ...) _CONSOLE_IF_ELSE_NO_ARGS(VAL,, ##__VA_ARGS__)
+#define _CONSOLE_IF_ELSE_NO_ARGS(TRUE, FALSE, ...) _CONSOLE_IF_ELSE_NO_ARGS_HELPER(_CONSOLE_CONCAT(_CONSOLE_IF_ELSE_NO_ARGS_, _CONSOLE_NUM_ARGS(__VA_ARGS__)), TRUE, FALSE, ##__VA_ARGS__)
+#define _CONSOLE_IF_ELSE_NO_ARGS_HELPER(C, TRUE, FALSE, ...) C(TRUE, FALSE, ##__VA_ARGS__)
+#define _CONSOLE_IF_ELSE_NO_ARGS_0(TRUE, FALSE) TRUE
+#define _CONSOLE_IF_ELSE_NO_ARGS_1(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_2(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_3(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_4(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_5(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_6(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_7(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_8(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_9(TRUE, FALSE, ...) FALSE
+#define _CONSOLE_IF_ELSE_NO_ARGS_10(TRUE, FALSE, ...) FALSE
+
 // Helper macros for defining console commands and their arguments
 #define _CONSOLE_COMMAND_DEF(CMD, DESC, ...) \
     _CONSOLE_COMMAND_ARGS_AND_HANDLER(CMD, ##__VA_ARGS__) \
-    static void CMD##_command_handler(const CMD##_args_t* args); \
     _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_DEFAULT_DEF(CMD) \
     static const console_command_def_t _##CMD##_DEF = { \
         .name = #CMD, \
         _CONSOLE_COMMAND_DEF_DESC_FIELD(DESC) \
-        .handler = (console_command_handler_t)CMD##_command_handler, \
+        _CONSOLE_IF_ELSE_NO_ARGS( \
+            .handler_no_args = (console_command_handler_no_args_t)CMD##_command_handler, \
+            .handler = (console_command_handler_t)CMD##_command_handler, \
+            ##__VA_ARGS__ \
+        ), \
         _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD) \
         .args = _##CMD##_ARGS_DEF, \
         .num_args = sizeof(_##CMD##_ARGS_DEF) / sizeof(console_arg_def_t), \
@@ -49,12 +71,15 @@ _Static_assert(_CONSOLE_NUM_ARGS(1,2,3,4,5,6,7,8,9,10) == 10, "_CONSOLE_NUM_ARGS
     static const console_command_def_t* const CMD = &_##CMD##_DEF
 #define _CONSOLE_COMMAND_DEF_WITH_TAB_COMPLETION(CMD, DESC, ...) \
     _CONSOLE_COMMAND_ARGS_AND_HANDLER(CMD, ##__VA_ARGS__) \
-    static void CMD##_command_handler(const CMD##_args_t* args); \
     _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_PROTOTYPE(CMD) \
     static const console_command_def_t _##CMD##_DEF = { \
         .name = #CMD, \
         _CONSOLE_COMMAND_DEF_DESC_FIELD(DESC) \
-        .handler = (console_command_handler_t)CMD##_command_handler, \
+        _CONSOLE_IF_ELSE_NO_ARGS( \
+            .handler_no_args = (console_command_handler_no_args_t)CMD##_command_handler, \
+            .handler = (console_command_handler_t)CMD##_command_handler, \
+            ##__VA_ARGS__ \
+        ), \
         _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD) \
         .args = _##CMD##_ARGS_DEF, \
         .num_args = sizeof(_##CMD##_ARGS_DEF) / sizeof(console_arg_def_t), \
@@ -78,16 +103,19 @@ _Static_assert(_CONSOLE_NUM_ARGS(1,2,3,4,5,6,7,8,9,10) == 10, "_CONSOLE_NUM_ARGS
 #define _CONSOLE_COMMAND_DEF_TAB_COMPLETE_ITER_FIELD(CMD)
 #endif
 #define _CONSOLE_COMMAND_ARGS_AND_HANDLER(CMD, ...) \
-    typedef struct { \
-        _CONSOLE_MAP(_CONSOLE_ARG_TYPE_HELPER, ##__VA_ARGS__) \
-        const void* const __dummy; /* dummy entry so the struct isn't empty */ \
-    } CMD##_args_t; \
-    _Static_assert(sizeof(CMD##_args_t) == (_CONSOLE_NUM_ARGS(__VA_ARGS__) + 1) * sizeof(void *), \
-        "Compiler created *_args_t struct of unexpected size"); \
+    _CONSOLE_IF_ARGS( \
+        typedef struct { \
+            _CONSOLE_MAP(_CONSOLE_ARG_TYPE_HELPER, ##__VA_ARGS__) \
+        } CMD##_args_t; \
+        _Static_assert(sizeof(CMD##_args_t) == _CONSOLE_NUM_ARGS(__VA_ARGS__) * sizeof(void *), "Compiler created *_args_t struct of unexpected size");, \
+        ##__VA_ARGS__\
+    ) \
     static const console_arg_def_t _##CMD##_ARGS_DEF[] = { \
         _CONSOLE_MAP(_CONSOLE_ARG_DEF_HELPER, ##__VA_ARGS__) \
     }; \
-    static void* _##CMD##_ARGS[_CONSOLE_NUM_ARGS(__VA_ARGS__)];
+    _Static_assert(sizeof(_##CMD##_ARGS_DEF) / sizeof(console_arg_def_t) == _CONSOLE_NUM_ARGS(__VA_ARGS__), "Internal error in code generation"); \
+    static void* _##CMD##_ARGS[_CONSOLE_NUM_ARGS(__VA_ARGS__)]; \
+    static void CMD##_command_handler(_CONSOLE_IF_ELSE_NO_ARGS(void, const CMD##_args_t* args, ##__VA_ARGS__));
 #define _CONSOLE_ARG_DEF_HELPER(...) _CONSOLE_ARG_DEF_HELPER2 __VA_ARGS__
 #if CONSOLE_HELP_COMMAND
 #define _CONSOLE_ARG_DEF_HELPER2(NAME, ENUM_TYPE, IS_OPTIONAL, C_TYPE, DESC) \
@@ -99,7 +127,3 @@ _Static_assert(_CONSOLE_NUM_ARGS(1,2,3,4,5,6,7,8,9,10) == 10, "_CONSOLE_NUM_ARGS
 #define _CONSOLE_ARG_TYPE_HELPER(...) _CONSOLE_ARG_TYPE_HELPER2 __VA_ARGS__
 #define _CONSOLE_ARG_TYPE_HELPER2(NAME, ENUM_TYPE, IS_OPTIONAL, C_TYPE, ...) \
     C_TYPE NAME;
-
-#else // !defined(__GNUC__)
-#error "Unsupported toolchain"
-#endif

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -469,6 +469,11 @@ static void help_command_handler(const help_args_t* args) {
 
 void console_init(const console_init_t* init) {
     m_init = *init;
+
+    // make sure to deregister previous commands
+    m_num_commands = 0;
+    memset(m_commands, 0, sizeof(m_commands) / sizeof(m_commands[0]));
+
 #if CONSOLE_HELP_COMMAND
     console_command_register(help);
 #endif

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -114,7 +114,7 @@ static void process_line(void) {
             if (!current_token) {
                 if (cmd) {
                     // too much whitespace
-                    write_str("ERROR: Extra whitespace between arguments\n");
+                    write_str("ERROR: Extra whitespace between arguments"CONSOLE_NEWLINE);
                     return;
                 } else {
                     // empty line - silently fail
@@ -142,13 +142,13 @@ static void process_line(void) {
                 if (!cmd) {
                     write_str("ERROR: Command not found (");
                     write_str(current_token);
-                    write_str(")\n");
+                    write_str(")"CONSOLE_NEWLINE);
                     return;
                 }
             } else {
                 // this is an argument
                 if (arg_index == cmd->num_args) {
-                    write_str("ERROR: Too many arguments\n");
+                    write_str("ERROR: Too many arguments"CONSOLE_NEWLINE);
                     return;
                 }
                 // validate the argument
@@ -159,7 +159,7 @@ static void process_line(void) {
                     write_str(arg->name);
                     write_str("' (");
                     write_str(current_token);
-                    write_str(")\n");
+                    write_str(")"CONSOLE_NEWLINE);
                     return;
                 }
                 cmd->args_ptr[arg_index] = parsed_arg.ptr;
@@ -175,7 +175,7 @@ static void process_line(void) {
         // nothing entered - silently fail
         return;
     } else if (arg_index < get_num_required_args(cmd)) {
-        write_str("ERROR: Too few arguments\n");
+        write_str("ERROR: Too few arguments"CONSOLE_NEWLINE);
         return;
     }
 
@@ -291,7 +291,7 @@ static void do_tab_complete(void) {
     } else if (longest_common_prefix == m_line_len) {
         // multiple matches and we've already entered the longest common prefix,
         // so print all the potential matches as a new line
-        write_str("\n");
+        write_str(CONSOLE_NEWLINE);
         for (uint32_t i = 0; i < m_num_commands; i++) {
             const console_command_def_t* cmd_def = &m_commands[i];
             if (strncmp(cmd_def->name, m_line_buffer, m_line_len)) {
@@ -302,7 +302,7 @@ static void do_tab_complete(void) {
             }
             write_str(cmd_def->name);
         }
-        write_str("\n");
+        write_str(CONSOLE_NEWLINE);
         // re-print the prompt and any valid, pending command
         write_str(CONSOLE_PROMPT);
         if (!m_line_invalid) {
@@ -329,12 +329,12 @@ static void help_command_handler(const help_args_t* args) {
         if (!cmd_def) {
             write_str("ERROR: Unknown command (");
             write_str(args->command);
-            write_str(")\n");
+            write_str(")"CONSOLE_NEWLINE);
             return;
         }
         if (cmd_def->desc) {
             write_str(cmd_def->desc);
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
         }
         write_str("Usage: ");
         write_str(args->command);
@@ -355,7 +355,7 @@ static void help_command_handler(const help_args_t* args) {
                 write_str("]");
             }
         }
-        write_str("\n");
+        write_str(CONSOLE_NEWLINE);
         for (uint32_t i = 0; i < cmd_def->num_args; i++) {
             const console_arg_def_t* arg_def = &cmd_def->args[i];
             write_str("  ");
@@ -369,10 +369,10 @@ static void help_command_handler(const help_args_t* args) {
                 write_str(" - ");
                 write_str(arg_def->desc);
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
         }
     } else {
-        write_str("Available commands:\n");
+        write_str("Available commands:"CONSOLE_NEWLINE);
         // get the max name length for padding
         uint32_t max_name_len = 0;
         for (uint32_t i = 0; i < m_num_commands; i++) {
@@ -395,7 +395,7 @@ static void help_command_handler(const help_args_t* args) {
                 write_str(" - ");
                 write_str(cmd_def->desc);
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
         }
     }
 }
@@ -406,7 +406,7 @@ void console_init(const console_init_t* init) {
 #if CONSOLE_HELP_COMMAND
     console_command_register(help);
 #endif
-    write_str("\n" CONSOLE_PROMPT);
+    write_str(CONSOLE_NEWLINE CONSOLE_PROMPT);
 }
 
 bool console_command_register(const console_command_def_t* cmd) {
@@ -493,12 +493,12 @@ void console_process(const uint8_t* data, uint32_t length) {
 #endif
             continue;
         }
-        if (c == '\n') {
+        if (c == CONSOLE_RETURN_KEY) {
             if (echo_str) {
                 write_str(echo_str);
                 echo_str = NULL;
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
             process_line();
             reset_line_and_print_prompt();
         } else if (c == CHAR_CTRL_C) {
@@ -506,7 +506,7 @@ void console_process(const uint8_t* data, uint32_t length) {
                 write_str(echo_str);
                 echo_str = NULL;
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
             reset_line_and_print_prompt();
             echo_str = NULL;
         } else if (!m_line_invalid && c == '\b') {
@@ -567,7 +567,7 @@ void console_process(const uint8_t* data, uint32_t length) {
 #else
     for (uint32_t i = 0; i < length; i++) {
         const char c = data[i];
-        if (c == '\n') {
+        if (c == CONSOLE_RETURN_KEY) {
             process_line();
             reset_line_and_print_prompt();
         } else if (!m_line_invalid && c >= ' ' && c <= '~') {

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -591,6 +591,10 @@ void console_print_line(const char* str) {
         write_str(CONSOLE_PROMPT);
         if (!m_line_invalid) {
             write_str(m_line_buffer);
+            // fix the cursor position if needed
+            for (uint32_t i = 0; i < m_line_len - m_cursor_pos; i++) {
+                write_str("\b");
+            }
         }
     }
 }

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -235,7 +235,11 @@ static void process_line(void) {
 
     // run the handler
     m_is_active = true;
-    cmd->handler(cmd->args_ptr);
+    if (cmd->num_args) {
+        cmd->handler(cmd->args_ptr);
+    } else {
+        cmd->handler_no_args();
+    }
     m_is_active = false;
 }
 

--- a/console/tests/Makefile
+++ b/console/tests/Makefile
@@ -1,14 +1,20 @@
 TARGET := test
-BUILD_DIR := build/
+BUILD_DIR_COMMON := build/
+BUILD_DIR_HELP := $(BUILD_DIR_COMMON)/help
+BUILD_DIR_NO_HELP := $(BUILD_DIR_COMMON)/no_help
 
 C_SOURCES := \
 	../src/console.c
 
 C_DEFS :=
 
-CXX_SOURCES := \
+CXX_SOURCES_HELP := \
 	main.cpp \
-	test_console.cpp
+	test_console_help.cpp
+
+CXX_SOURCES_NO_HELP := \
+	main.cpp \
+	test_console_no_help.cpp
 
 CXX_INCLUDES := \
 	-I../include
@@ -16,9 +22,11 @@ CXX_INCLUDES := \
 CC := gcc
 CXX := g++
 
-OBJECTS := $(addprefix $(BUILD_DIR)/,$(notdir $(CXX_SOURCES:.cpp=.o))) $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
+OBJECTS_HELP := $(addprefix $(BUILD_DIR_HELP)/,$(notdir $(CXX_SOURCES_HELP:.cpp=.o))) $(addprefix $(BUILD_DIR_HELP)/,$(notdir $(C_SOURCES:.c=.o)))
+OBJECTS_NO_HELP := $(addprefix $(BUILD_DIR_NO_HELP)/,$(notdir $(CXX_SOURCES_NO_HELP:.cpp=.o))) $(addprefix $(BUILD_DIR_NO_HELP)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
-vpath %.cpp $(sort $(dir $(CXX_SOURCES)))
+vpath %.cpp $(sort $(dir $(CXX_SOURCES_HELP)))
+vpath %.cpp $(sort $(dir $(CXX_SOURCES_NO_HELP)))
 
 CFLAGS := $(CXX_INCLUDES) -g3 -Werror $(addprefix -D,$(C_DEFS))
 CPP_FLAGS :=
@@ -37,31 +45,49 @@ CPP_FLAGS += -D_Static_assert=static_assert
 endif
 endif
 
-$(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
+$(BUILD_DIR_HELP)/%.o: %.c Makefile | $(BUILD_DIR_HELP)
 	@echo "Compiling $(notdir $@)"
-	@$(CC) -c $(CFLAGS) -MD -MF"$(@:%.o=%.d)" $< -o $@
+	@$(CC) -c $(CFLAGS) -DCONSOLE_HELP_COMMAND=1 -MD -MF"$(@:%.o=%.d)" $< -o $@
 
-$(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
+$(BUILD_DIR_NO_HELP)/%.o: %.c Makefile | $(BUILD_DIR_NO_HELP)
 	@echo "Compiling $(notdir $@)"
-	@$(CXX) -c $(CFLAGS) $(CPP_FLAGS) -MD -MF"$(@:%.o=%.d)" $< -o $@
+	@$(CC) -c $(CFLAGS) -DCONSOLE_HELP_COMMAND=0 -MD -MF"$(@:%.o=%.d)" $< -o $@
 
-$(BUILD_DIR)/$(TARGET): $(OBJECTS) Makefile | $(BUILD_DIR)
+$(BUILD_DIR_HELP)/%.o: %.cpp Makefile | $(BUILD_DIR_HELP)
+	@echo "Compiling $(notdir $@)"
+	@$(CXX) -c $(CFLAGS) -DCONSOLE_HELP_COMMAND=1 $(CPP_FLAGS) -MD -MF"$(@:%.o=%.d)" $< -o $@
+
+$(BUILD_DIR_NO_HELP)/%.o: %.cpp Makefile | $(BUILD_DIR_NO_HELP)
+	@echo "Compiling $(notdir $@)"
+	@$(CXX) -c $(CFLAGS) -DCONSOLE_HELP_COMMAND=0 $(CPP_FLAGS) -MD -MF"$(@:%.o=%.d)" $< -o $@
+
+$(BUILD_DIR_HELP)/$(TARGET): $(OBJECTS_HELP) Makefile | $(BUILD_DIR_HELP)
 	@echo "Linking $(notdir $@)"
-	@$(CXX) $(OBJECTS) -o $@ $(LDFLAGS)
+	@$(CXX) $(OBJECTS_HELP) -o $@ $(LDFLAGS)
 
-$(BUILD_DIR):
+$(BUILD_DIR_NO_HELP)/$(TARGET): $(OBJECTS_NO_HELP) Makefile | $(BUILD_DIR_NO_HELP)
+	@echo "Linking $(notdir $@)"
+	@$(CXX) $(OBJECTS_NO_HELP) -o $@ $(LDFLAGS)
+
+$(BUILD_DIR_HELP):
 	@mkdir -p $@
 
-build: $(BUILD_DIR)/$(TARGET)
+$(BUILD_DIR_NO_HELP):
+	@mkdir -p $@
 
-test: $(BUILD_DIR)/$(TARGET)
-	@$<
+build: $(BUILD_DIR_HELP)/$(TARGET) $(BUILD_DIR_NO_HELP)/$(TARGET)
+
+test: $(BUILD_DIR_HELP)/$(TARGET) $(BUILD_DIR_NO_HELP)/$(TARGET)
+	@echo "Running test with help command"
+	@$(BUILD_DIR_HELP)/$(TARGET)
+	@echo "Running test without help command"
+	@$(BUILD_DIR_NO_HELP)/$(TARGET)
 
 clean:
 	@echo "Deleting build folder"
-	@rm -fR $(BUILD_DIR)
+	@rm -fR $(BUILD_DIR_COMMON)
 
-
--include $(wildcard $(BUILD_DIR)/*.d)
+-include $(wildcard $(BUILD_DIR_HELP)/*.d)
+-include $(wildcard $(BUILD_DIR_NO_HELP)/*.d)
 .PHONY: test clean build
 .DEFAULT_GOAL := test

--- a/console/tests/main.cpp
+++ b/console/tests/main.cpp
@@ -28,6 +28,7 @@ extern "C" {
     _res ? _arg : DEFAULT_VALUE; \
   })
 
+#if CONSOLE_HELP_COMMAND
 CONSOLE_COMMAND_DEF(say_hi, "Says hi");
 CONSOLE_COMMAND_DEF(say_bye, "Says bye");
 CONSOLE_COMMAND_DEF(minimal, NULL);
@@ -40,6 +41,20 @@ CONSOLE_COMMAND_DEF(stroff, "Prints a string starting from an offset",
   CONSOLE_STR_ARG_DEF(str, "The string"),
   CONSOLE_INT_ARG_DEF(offset, "Offset into the string")
 );
+#else
+CONSOLE_COMMAND_DEF(say_hi);
+CONSOLE_COMMAND_DEF(say_bye);
+CONSOLE_COMMAND_DEF(minimal);
+CONSOLE_COMMAND_DEF(add,
+  CONSOLE_INT_ARG_DEF(num1),
+  CONSOLE_INT_ARG_DEF(num2),
+  CONSOLE_OPTIONAL_INT_ARG_DEF(num3)
+);
+CONSOLE_COMMAND_DEF(stroff,
+  CONSOLE_STR_ARG_DEF(str),
+  CONSOLE_INT_ARG_DEF(offset)
+);
+#endif
 
 std::vector<char> g_console_write_buffer;
 

--- a/console/tests/main.cpp
+++ b/console/tests/main.cpp
@@ -65,15 +65,15 @@ static void write_function(const char* str) {
   }
 }
 
-static void say_hi_command_handler(const say_hi_args_t* args) {
+static void say_hi_command_handler(void) {
   write_function("hi\n");
 }
 
-static void say_bye_command_handler(const say_bye_args_t* args) {
+static void say_bye_command_handler(void) {
   write_function("hi\n");
 }
 
-static void minimal_command_handler(const minimal_args_t* args) {
+static void minimal_command_handler(void) {
   write_function("Hello world!\n");
 }
 

--- a/console/tests/test_console.cpp
+++ b/console/tests/test_console.cpp
@@ -8,6 +8,9 @@ extern "C" {
 
 #include <cstring>
 
+#define LEFT_ARROW_SEQUENCE   "\x1b[D"
+#define RIGHT_ARROW_SEQUENCE  "\x1b[C"
+
 extern std::vector<char> g_console_write_buffer;
 
 #define EXPECT_WRITE_BUFFER(str) do { \
@@ -202,4 +205,52 @@ TEST(ConsoleTest, TestTabComplete) {
 
   process_line("\t");
   EXPECT_WRITE_BUFFER("");
+
+  process_line("\n");
+  EXPECT_WRITE_BUFFER("\nhi\n> ");
+}
+
+TEST(ConsoleTest, TestLeftRightArrow) {
+  process_line("sayh");
+  EXPECT_WRITE_BUFFER("sayh");
+
+  process_line(LEFT_ARROW_SEQUENCE);
+  EXPECT_WRITE_BUFFER("\b");
+
+  process_line(RIGHT_ARROW_SEQUENCE);
+  EXPECT_WRITE_BUFFER("h");
+
+  process_line(LEFT_ARROW_SEQUENCE);
+  EXPECT_WRITE_BUFFER("\b");
+
+  process_line("_");
+  EXPECT_WRITE_BUFFER("_h\b");
+
+  process_line(RIGHT_ARROW_SEQUENCE);
+  EXPECT_WRITE_BUFFER("h");
+
+  process_line("i");
+  EXPECT_WRITE_BUFFER("i");
+
+  process_line("\n");
+  EXPECT_WRITE_BUFFER("\nhi\n> ");
+}
+
+TEST(ConsoleTest, TestPrintLine) {
+  process_line("say_");
+  EXPECT_WRITE_BUFFER("say_");
+
+  process_line(LEFT_ARROW_SEQUENCE);
+  EXPECT_WRITE_BUFFER("\b");
+
+  console_print_line("Log line\n");
+  EXPECT_WRITE_BUFFER(
+    "\rLog line\n"
+    "> say_\b");
+
+  process_line(RIGHT_ARROW_SEQUENCE);
+  EXPECT_WRITE_BUFFER("_");
+
+  process_line("hi\n");
+  EXPECT_WRITE_BUFFER("hi\nhi\n> ");
 }

--- a/console/tests/test_console_help.cpp
+++ b/console/tests/test_console_help.cpp
@@ -1,0 +1,64 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+
+#include "anchor/console/console.h"
+
+};
+
+#include <cstring>
+
+extern std::vector<char> g_console_write_buffer;
+
+#define EXPECT_WRITE_BUFFER(str) do { \
+    g_console_write_buffer.push_back('\0'); \
+    const char* write_buffer_str = g_console_write_buffer.data(); \
+    EXPECT_STREQ(write_buffer_str, str); \
+    g_console_write_buffer.clear(); \
+  } while (0)
+
+static void process_line(const char* str) {
+  console_process((const uint8_t*)str, (uint32_t)strlen(str));
+}
+
+#if CONSOLE_HELP_COMMAND
+TEST(ConsoleTest, TestHelpCommand) {
+  process_line("help\n");
+  EXPECT_WRITE_BUFFER("help\n"
+    "Available commands:\n"
+    "  help    - List all commands, or give details about a specific command\n"
+    "  say_hi  - Says hi\n"
+    "  say_bye - Says bye\n"
+    "  minimal\n"
+    "  add     - Add two numbers\n"
+    "  stroff  - Prints a string starting from an offset\n"
+    "> ");
+
+  process_line("help add\n");
+  EXPECT_WRITE_BUFFER(
+    "help add\n"
+    "Add two numbers\n"
+    "Usage: add num1 num2 [num3]\n"
+    "  num1 - First number\n"
+    "  num2 - Second number\n"
+    "  num3 - Third (optional) number\n"
+    "> ");
+
+  process_line("help minimal\n");
+  EXPECT_WRITE_BUFFER(
+    "help minimal\n"
+    "Usage: minimal\n"
+    "> ");
+}
+
+TEST(ConsoleTest, TestHelpTabCompletion) {
+  process_line("help sa\t");
+  EXPECT_WRITE_BUFFER("help say_");
+
+  process_line("\t");
+  EXPECT_WRITE_BUFFER("\nsay_hi say_bye\n> help say_");
+
+  process_line("h\t");
+  EXPECT_WRITE_BUFFER("hi");
+}
+#endif

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -256,3 +256,17 @@ TEST(ConsoleTest, TestPrintLine) {
   process_line("hi\n");
   EXPECT_WRITE_BUFFER("hi\nhi\n> ");
 }
+
+TEST(ConsoleTest, TestInitClearsPreviousCommands) {
+  // try to register an existing command, should fail
+  EXPECT_FALSE(console_command_register(say_hi));
+
+  // re-init, just use dummy init for now
+  const console_init_t init_console = {
+    .write_function = NULL,
+  };
+  console_init(&init_console);
+
+  // try to register same command, should succeed now
+  EXPECT_TRUE(console_command_register(say_hi));
+}

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -164,6 +164,7 @@ TEST(ConsoleTest, TestInvalidStroffCommand) {
     "ERROR: Invalid value for 'offset' (test)\n> ");
 }
 
+#if CONSOLE_HELP_COMMAND
 TEST(ConsoleTest, TestHelpCommand) {
   process_line("help\n");
   EXPECT_WRITE_BUFFER("help\n"
@@ -192,6 +193,7 @@ TEST(ConsoleTest, TestHelpCommand) {
     "Usage: minimal\n"
     "> ");
 }
+#endif
 
 TEST(ConsoleTest, TestTabComplete) {
   process_line("sa\t");

--- a/fsm/README.md
+++ b/fsm/README.md
@@ -24,8 +24,8 @@ state entry / exit callbacks, if there is an appropriate transition defined.
 
 Additional features of the FSM library can be enabled by compiling with the
 following defines:
-* `FSM_USE_LOGGING` - enable logging of state transitions via the `logging`
-library.
+* `FSM_USE_LOGGING` - Enables logging of state transitions and other debugging
+information via the `logging` library.
 
 ## Example
 

--- a/fsm/README.md
+++ b/fsm/README.md
@@ -24,8 +24,9 @@ state entry / exit callbacks, if there is an appropriate transition defined.
 
 Additional features of the FSM library can be enabled by compiling with the
 following defines:
-* `FSM_USE_LOGGING` - Enables logging of state transitions and other debugging
-information via the `logging` library.
+* `FSM_USE_LOGGING` - Controls logging via the `logging` library. Set to 1 to
+enable logging of error conditions and state transitions. Set to 2 to also
+enable logging of ignored events.
 
 ## Example
 

--- a/fsm/src/fsm.c
+++ b/fsm/src/fsm.c
@@ -42,4 +42,7 @@ void fsm_process_event(fsm_t* fsm, fsm_event_t event) {
             return;
         }
     }
+#ifdef FSM_USE_LOGGING
+    LOG_INFO("Ignoring event with no defined transition (state=%s, event=%s)", impl->state->name, event->name);
+#endif
 }

--- a/fsm/src/fsm.c
+++ b/fsm/src/fsm.c
@@ -1,6 +1,10 @@
 #include "anchor/fsm/fsm.h"
 
-#ifdef FSM_USE_LOGGING
+#ifndef FSM_USE_LOGGING
+#define FSM_USE_LOGGING 0
+#endif
+
+#if FSM_USE_LOGGING
 #include "anchor/logging/logging.h"
 #endif
 
@@ -22,7 +26,7 @@ void fsm_init(fsm_t* fsm) {
 void fsm_process_event(fsm_t* fsm, fsm_event_t event) {
     fsm_impl_t* impl = (fsm_impl_t*)(fsm->_private);
     if (impl->in_transition) {
-#ifdef FSM_USE_LOGGING
+#if FSM_USE_LOGGING >= 1
         LOG_ERROR("Attempting to process event from handler, dropping event");
 #endif
         return;
@@ -31,7 +35,7 @@ void fsm_process_event(fsm_t* fsm, fsm_event_t event) {
         const fsm_transition_t* transition = &fsm->transitions[i];
         if (impl->state == transition->from_state && event == transition->event) {
             // execute this transition
-#ifdef FSM_USE_LOGGING
+#if FSM_USE_LOGGING >= 1
             LOG_INFO("Executing transition from %s to %s (event=%s)", transition->from_state->name, transition->to_state->name, event->name);
 #endif
             impl->in_transition = true;
@@ -42,7 +46,7 @@ void fsm_process_event(fsm_t* fsm, fsm_event_t event) {
             return;
         }
     }
-#ifdef FSM_USE_LOGGING
+#if FSM_USE_LOGGING >= 2
     LOG_INFO("Ignoring event with no defined transition (state=%s, event=%s)", impl->state->name, event->name);
 #endif
 }

--- a/logging/README.md
+++ b/logging/README.md
@@ -28,6 +28,19 @@ $(BUILD_DIR)/%.o: %.c
 In order to prefix the file name with a module name, define
 `LOGGING_MODULE_NAME` before including `logging.h` in your source file.
 
+### Compile Options
+
+Parameters and additional features of the logging library can be configured
+with the following defines:
+* `LOGGING_MAX_MSG_LENGTH` - The maximum length (128 by default) of a log
+message not including the extra prefixes added by the logging library.
+* `LOGGING_USE_DATETIME` - Prefixes log lines with a full datetime string
+(YYYY-MM-DD HH:MM:SS.SSS) instead of a system uptime (HHH:MM:SS.SSS) and changes
+`time_ms_function` to return a `uint64_t` which should be the number of
+milliseconds since epoch. This defaults to 0.
+
+* LOGGING_USE_DATETIME
+
 ## Example Output
 ```
   0:00:00.626 WARN  system.c:199: Last reset due to software reset

--- a/logging/README.md
+++ b/logging/README.md
@@ -14,13 +14,13 @@ the level of each module can be changed using the `LOG_SET_LEVEL(...)` macro.
 
 ### Shorter File Names
 
-By default, the logging library will use the `__FILE__` define provided by gcc
-to get the name of the file. To reduce code size, and make the logs easier to
-read, it's recommended to generate a `FILENAME` define at compile time for each
-source file. An example Make rule which does this is shown below:
+The logging library will use the `__FILE__` define provided by gcc to get the
+name of the file. To reduce code size, and make the logs easier to read, it's
+recommended to use the `-fmacro-prefix-map={DIRECTORY}=` GCC option.
+An example Make rule which does this is shown below:
 ```
 $(BUILD_DIR)/%.o: %.c
-	@$(CC) -c -DFILENAME=\"$(notdir $<)\" $(CFLAGS) $< -o $@
+	@$(CC) -c -fmacro-prefix-map=$(dir $<)/= $(CFLAGS) $< -o $@
 ```
 
 ### Module Prefix

--- a/logging/README.md
+++ b/logging/README.md
@@ -37,14 +37,15 @@ In order to set a default logging level at compile time, define
 
 Parameters and additional features of the logging library can be configured
 with the following defines:
+* `LOGGING_CUSTOM_HANDLER` - Allows for specifying a custom log handler, which
+bypasses any formatting done by logging library.
 * `LOGGING_MAX_MSG_LENGTH` - The maximum length (128 by default) of a log
-message not including the extra prefixes added by the logging library.
+message not including the extra prefixes added by the logging library. This
+setting is not used if LOGGING_CUSTOM_HANDLER is set.
 * `LOGGING_USE_DATETIME` - Prefixes log lines with a full datetime string
-(YYYY-MM-DD HH:MM:SS.SSS) instead of a system uptime (HHH:MM:SS.SSS) and changes
-`time_ms_function` to return a `uint64_t` which should be the number of
+(YYYY-MM-DD HH:MM:SS.SSS) instead of a system uptime (HHH:MM:SS.SSS) and
+changes `time_ms_function` to return a `uint64_t` which should be the number of
 milliseconds since epoch. This defaults to 0.
-
-* LOGGING_USE_DATETIME
 
 ## Example Output
 ```

--- a/logging/README.md
+++ b/logging/README.md
@@ -28,6 +28,11 @@ $(BUILD_DIR)/%.o: %.c
 In order to prefix the file name with a module name, define
 `LOGGING_MODULE_NAME` before including `logging.h` in your source file.
 
+### Per-File Default Level
+
+In order to set a default logging level at compile time, define
+`LOGGING_FILE_DEFAULT_LEVEL` before including `logging.h`.
+
 ### Compile Options
 
 Parameters and additional features of the logging library can be configured

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -20,6 +20,11 @@ extern "C" {
 #define LOGGING_MAX_MSG_LENGTH 128
 #endif
 
+// Define this to prefix logs with datetime instead of system time (changes time_ms_function() to return a uint64_t)
+#ifndef LOGGING_USE_DATETIME
+#define LOGGING_USE_DATETIME 0
+#endif
+
 // The application's build scripts can define FILENAME to the name of the file without the full path in order to save code space
 #ifndef FILENAME
 #define FILENAME __FILE__
@@ -42,8 +47,13 @@ typedef struct {
     void(*raw_write_function)(logging_level_t level, const char* module_name, const char* str);
     // A lock function which is called to make the logging library thread-safe
     void(*lock_function)(bool acquire);
+#if LOGGING_USE_DATETIME
+    // A function which is called to get the number of milliseconds since epoch
+    uint64_t(*time_ms_function)(void);
+#else
     // A function which is called to get the current system time in milliseconds
     uint32_t(*time_ms_function)(void);
+#endif
     // The default logging level
     logging_level_t default_level;
 } logging_init_t;

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -99,6 +99,9 @@ void logging_format_line(const logging_line_t* log_line, char* buffer, uint32_t 
 // Need to include this after our types or defined
 #include "logging_internal.h"
 
+// Returns whether a given level is active
+#define LOG_LEVEL_IS_ACTIVE(LEVEL) logging_level_is_active(&_logging_logger, LEVEL)
+
 // Change the logging threshold for the current module
 #define LOG_SET_LEVEL(LEVEL) _logging_logger.level = LEVEL
 

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -68,7 +68,7 @@ typedef struct {
 
 // Change the logging threshold for the current module
 
-#define LOG_SET_LEVEL(LEVEL) _logging_logger->level = LEVEL
+#define LOG_SET_LEVEL(LEVEL) _logging_logger.level = LEVEL
 
 // Macros for logging at each level
 #define LOG_DEBUG(...) _LOG_LEVEL_IMPL(LOGGING_LEVEL_DEBUG, __VA_ARGS__)

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -58,7 +58,7 @@ typedef struct {
 } logging_logger_t;
 
 // Change the logging threshold for the current module
-#define LOG_SET_LEVEL(LEVEL) logging_module_set_level_impl(&_logging_logger, LEVEL)
+#define LOG_SET_LEVEL(LEVEL) logging_set_level_impl(&_logging_logger, LEVEL)
 
 // Macros for logging at each level
 #define LOG_DEBUG(...) _LOG_LEVEL_IMPL(LOGGING_LEVEL_DEBUG, __VA_ARGS__)

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -26,11 +26,6 @@ extern "C" {
 #define LOGGING_USE_DATETIME 0
 #endif
 
-// The application's build scripts can define FILENAME to the name of the file without the full path in order to save code space
-#ifndef FILENAME
-#define FILENAME __FILE__
-#endif
-
 // NOTE: LOGGING_MODULE_NAME can be defined before including this header in order to specify the module which the file belongs to
 
 typedef enum {
@@ -82,7 +77,7 @@ typedef struct {
 #define LOG_ERROR(...) _LOG_LEVEL_IMPL(LOGGING_LEVEL_ERROR, __VA_ARGS__)
 
 // Internal implementation macros / functions which are called via the macros above
-#define _LOG_LEVEL_IMPL(LEVEL, ...) logging_log_impl(&_logging_logger, LEVEL, FILENAME, __LINE__, __VA_ARGS__)
+#define _LOG_LEVEL_IMPL(LEVEL, ...) logging_log_impl(&_logging_logger, LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) _LOGGING_FORMAT_ATTR;
 
 // Per-file context object which we should create

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -1,5 +1,8 @@
 // We explicitly don't use include guards as this file should not be included recursively.
 
+// NOTE: LOGGING_MODULE_NAME can be defined before including this header in order to specify the module
+// NOTE: LOGGING_FILE_DEFAULT_LEVEL can be defined before including this header in order to change the default log level
+
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -8,25 +11,22 @@
 extern "C" {
 #endif
 
-#ifdef _MSC_VER
-#define _LOGGING_FORMAT_ATTR
-#define _LOGGING_USED_ATTR
-#else
-#define _LOGGING_FORMAT_ATTR __attribute__((format(printf, 5, 6)))
-#define _LOGGING_USED_ATTR __attribute__((used))
-#endif
-
 // The maximum length of a log message (not including extra formatting)
 #ifndef LOGGING_MAX_MSG_LENGTH
-#define LOGGING_MAX_MSG_LENGTH 128
+#define LOGGING_MAX_MSG_LENGTH  128
 #endif
 
-// Define this to prefix logs with datetime instead of system time (changes time_ms_function() to return a uint64_t)
+// Define this to prefix logs with datetime instead of system time (also changes logging_timestamp_t to a uint64_t)
 #ifndef LOGGING_USE_DATETIME
-#define LOGGING_USE_DATETIME 0
+#define LOGGING_USE_DATETIME    0
 #endif
 
-// NOTE: LOGGING_MODULE_NAME can be defined before including this header in order to specify the module which the file belongs to
+// Type which represents a log timestamp in milliseconds
+#if LOGGING_USE_DATETIME
+typedef uint64_t logging_timestamp_t;
+#else
+typedef uint32_t logging_timestamp_t;
+#endif
 
 typedef enum {
     LOGGING_LEVEL_DEFAULT = 0, // Used to represent the default level specified to logging_init()
@@ -43,13 +43,8 @@ typedef struct {
     void(*raw_write_function)(logging_level_t level, const char* module_name, const char* str);
     // A lock function which is called to make the logging library thread-safe
     void(*lock_function)(bool acquire);
-#if LOGGING_USE_DATETIME
-    // A function which is called to get the number of milliseconds since epoch
-    uint64_t(*time_ms_function)(void);
-#else
-    // A function which is called to get the current system time in milliseconds
-    uint32_t(*time_ms_function)(void);
-#endif
+    // A function which is called to get the current timestamp in milliseconds (either an epoch time or system uptime)
+    logging_timestamp_t(*time_ms_function)(void);
     // The default logging level
     logging_level_t default_level;
 } logging_init_t;
@@ -60,14 +55,10 @@ bool logging_init(const logging_init_t* init);
 // Logs a line which was manually captured through a printf-style function hook / macro (filtered by the default level)
 void logging_log_line(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args);
 
-// Internal type used to represent a logger (should not be directly modified)
-typedef struct {
-    logging_level_t level;
-    const char* const module_prefix;
-} logging_logger_t;
+// Need to include this after our types or defined
+#include "logging_internal.h"
 
 // Change the logging threshold for the current module
-
 #define LOG_SET_LEVEL(LEVEL) _logging_logger.level = LEVEL
 
 // Macros for logging at each level
@@ -75,26 +66,6 @@ typedef struct {
 #define LOG_INFO(...) _LOG_LEVEL_IMPL(LOGGING_LEVEL_INFO, __VA_ARGS__)
 #define LOG_WARN(...) _LOG_LEVEL_IMPL(LOGGING_LEVEL_WARN, __VA_ARGS__)
 #define LOG_ERROR(...) _LOG_LEVEL_IMPL(LOGGING_LEVEL_ERROR, __VA_ARGS__)
-
-// Internal implementation macros / functions which are called via the macros above
-#define _LOG_LEVEL_IMPL(LEVEL, ...) logging_log_impl(&_logging_logger, LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) _LOGGING_FORMAT_ATTR;
-
-// Per-file context object which we should create
-static logging_logger_t _logging_logger _LOGGING_USED_ATTR = {
-#ifdef LOGGING_FILE_DEFAULT_LEVEL
-    .level = LOGGING_FILE_DEFAULT_LEVEL,
-#undef LOGGING_FILE_DEFAULT_LEVEL
-#else
-    .level = LOGGING_LEVEL_DEFAULT,
-#endif
-#ifdef LOGGING_MODULE_NAME
-    .module_prefix = LOGGING_MODULE_NAME ":",
-#undef LOGGING_MODULE_NAME
-#else
-    .module_prefix = 0,
-#endif
-};
 
 #ifdef __cplusplus
 }

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -62,7 +62,7 @@ typedef struct {
 // Initialize the logging library
 bool logging_init(const logging_init_t* init);
 
-// Logs a line which was manually captured through a printf-style function hook / macro
+// Logs a line which was manually captured through a printf-style function hook / macro (filtered by the default level)
 void logging_log_line(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args);
 
 // Internal type used to represent a logger (should not be directly modified)

--- a/logging/include/anchor/logging/logging.h
+++ b/logging/include/anchor/logging/logging.h
@@ -1,6 +1,7 @@
 // We explicitly don't use include guards as this file should not be included recursively.
 
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -60,6 +61,9 @@ typedef struct {
 
 // Initialize the logging library
 bool logging_init(const logging_init_t* init);
+
+// Logs a line which was manually captured through a printf-style function hook / macro
+void logging_log_line(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args);
 
 // Internal type used to represent a logger (should not be directly modified)
 typedef struct {

--- a/logging/include/anchor/logging/logging_internal.h
+++ b/logging/include/anchor/logging/logging_internal.h
@@ -19,8 +19,9 @@ typedef struct {
 } logging_logger_t;
 
 // Internal implementation macros / functions which are called via the LOG_* macros
-#define _LOG_LEVEL_IMPL(LEVEL, ...) logging_log_impl(&_logging_logger, LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) _LOGGING_FORMAT_ATTR;
+#define _LOG_LEVEL_IMPL(LEVEL, ...) if (logging_level_is_active(&_logging_logger, LEVEL)) logging_log_impl(LEVEL, __FILE__, __LINE__, _logging_logger.module_prefix, __VA_ARGS__)
+bool logging_level_is_active(logging_logger_t* logger, logging_level_t level);
+void logging_log_impl(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, ...) _LOGGING_FORMAT_ATTR;
 
 #ifdef LOGGING_MODULE_NAME
 #define _LOGGING_MODULE_PREFIX LOGGING_MODULE_NAME ":"

--- a/logging/include/anchor/logging/logging_internal.h
+++ b/logging/include/anchor/logging/logging_internal.h
@@ -1,0 +1,50 @@
+// We explicitly don't use include guards as this file should not be included recursively.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _MSC_VER
+#define _LOGGING_FORMAT_ATTR
+#define _LOGGING_USED_ATTR
+#else
+#define _LOGGING_FORMAT_ATTR __attribute__((format(printf, 5, 6)))
+#define _LOGGING_USED_ATTR __attribute__((used))
+#endif
+
+// Internal type used to represent a logger (should not be directly modified)
+typedef struct {
+    logging_level_t level;
+    const char* const module_prefix;
+} logging_logger_t;
+
+// Internal implementation macros / functions which are called via the LOG_* macros
+#define _LOG_LEVEL_IMPL(LEVEL, ...) logging_log_impl(&_logging_logger, LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) _LOGGING_FORMAT_ATTR;
+
+#ifdef LOGGING_MODULE_NAME
+#define _LOGGING_MODULE_PREFIX LOGGING_MODULE_NAME ":"
+#undef LOGGING_MODULE_NAME
+#else
+#define _LOGGING_MODULE_PREFIX 0
+#endif
+
+#ifndef LOGGING_FILE_DEFAULT_LEVEL
+#define LOGGING_FILE_DEFAULT_LEVEL LOGGING_LEVEL_DEFAULT
+#endif
+
+// Per-file context object which we should create
+static logging_logger_t _logging_logger _LOGGING_USED_ATTR = {
+    .level = LOGGING_FILE_DEFAULT_LEVEL,
+    .module_prefix = _LOGGING_MODULE_PREFIX,
+};
+
+// Clean up any configuration / internal defines
+#undef LOGGING_FILE_DEFAULT_LEVEL
+#undef _LOGGING_MODULE_PREFIX
+#undef _LOGGING_FORMAT_ATTR
+#undef _LOGGING_USED_ATTR
+
+#ifdef __cplusplus
+}
+#endif

--- a/logging/src/logging.c
+++ b/logging/src/logging.c
@@ -5,7 +5,11 @@
 #include <string.h>
 
 #define LEVEL_PREFIX_LENGTH     6
-#define TIME_LENGTH             16
+#if LOGGING_USE_DATETIME
+#define TIME_LENGTH             24
+#else
+#define TIME_LENGTH             14
+#endif
 #define FILE_NAME_LENGTH        32
 #define FULL_LOG_MAX_LENGTH     (LOGGING_MAX_MSG_LENGTH + LEVEL_PREFIX_LENGTH + TIME_LENGTH + FILE_NAME_LENGTH + 1)
 
@@ -16,6 +20,18 @@ typedef struct {
 } logger_impl_t;
 _Static_assert(sizeof(logger_impl_t) == sizeof(((logging_logger_t*)0)->_private), "Invalid context size");
 
+#if LOGGING_USE_DATETIME
+typedef struct {
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+    uint16_t ms;
+} datetime_t;
+#endif
+
 static const char* LEVEL_PREFIX[] = {
     [LOGGING_LEVEL_DEFAULT] =   "????? ", // should never be printed
     [LOGGING_LEVEL_DEBUG] =     "DEBUG ",
@@ -23,10 +39,61 @@ static const char* LEVEL_PREFIX[] = {
     [LOGGING_LEVEL_WARN] =      "WARN  ",
     [LOGGING_LEVEL_ERROR] =     "ERROR ",
 };
+#if LOGGING_USE_DATETIME
+static const uint8_t DAYS_PER_MONTH[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+#endif
 
 static logging_init_t m_init;
-static char m_line_time_buffer[TIME_LENGTH];
 static char m_write_buffer[FULL_LOG_MAX_LENGTH];
+
+#if LOGGING_USE_DATETIME
+static bool is_leap_year(uint16_t year) {
+    // A year is a leap year if it's evenly divisible by 4 unless it's evenly divisible by 100 but not 400.
+    return ((year & 3) == 0 && (year % 100)) || (year % 400) == 0;
+}
+
+static void timestamp_to_datetime(uint64_t ms, datetime_t* datetime) {
+    uint32_t seconds = ms / 1000;
+
+    // Calculate days since epoch (add 1 for the current day)
+    uint32_t days = seconds / 86400 + 1;
+    seconds = seconds % 86400;
+
+    // Calculate the hour, minute, seconds of the datetime
+    datetime->hour = (uint8_t)(seconds / 3600);
+    seconds = seconds % 3600;
+    datetime->minute = (uint8_t)(seconds / 60);
+    datetime->second = (uint8_t)(seconds % 60);
+    datetime->ms = ms % 1000;
+
+    // Calculate the year
+    uint16_t days_in_year = 365;
+    datetime->year = 1970;
+    while (days > days_in_year) {
+        days -= days_in_year;
+        datetime->year++;
+        if (is_leap_year(datetime->year)) {
+            // this is a leap year
+            days_in_year = 366;
+        } else {
+            days_in_year = 365;
+        }
+    }
+
+    // Calculate the month and day
+    datetime->month = 0;
+    for (uint8_t month = 1; month <= 12; month++) {
+        const uint8_t days_in_month = (month == 2 && is_leap_year(datetime->year)) ? 29 : DAYS_PER_MONTH[month-1];
+        if (days <= days_in_month) {
+            datetime->month = month;
+            break;
+        } else {
+            days -= days_in_month;
+        }
+    }
+    datetime->day = days;
+}
+#endif
 
 bool logging_init(const logging_init_t* init) {
     if ((!init->write_function && !init->raw_write_function) || init->default_level == LOGGING_LEVEL_DEFAULT) {
@@ -49,6 +116,13 @@ void logging_log_impl(logging_logger_t* logger, logging_level_t level, const cha
 
     // time
     if (m_init.time_ms_function) {
+#if LOGGING_USE_DATETIME
+        uint64_t current_time = m_init.time_ms_function();
+        datetime_t datetime;
+        timestamp_to_datetime(current_time, &datetime);
+        snprintf(m_write_buffer, FULL_LOG_MAX_LENGTH, "%04u-%02u-%02u %02u:%02u:%02u.%03u ", datetime.year, datetime.month,
+            datetime.day, datetime.hour, datetime.minute, datetime.second, datetime.ms);
+#else
         uint32_t current_time = m_init.time_ms_function();
         const uint16_t ms = current_time % 1000;
         current_time /= 1000;
@@ -58,6 +132,7 @@ void logging_log_impl(logging_logger_t* logger, logging_level_t level, const cha
         current_time /= 60;
         const uint16_t hours = current_time;
         snprintf(m_write_buffer, FULL_LOG_MAX_LENGTH, "%3u:%02u:%02u.%03u ", hours, min, sec, ms);
+#endif
     }
 
     // level
@@ -72,7 +147,6 @@ void logging_log_impl(logging_logger_t* logger, logging_level_t level, const cha
     snprintf(&m_write_buffer[strlen(m_write_buffer)], FULL_LOG_MAX_LENGTH-strlen(m_write_buffer), "%s", file);
 
     // line number
-    snprintf(m_line_time_buffer, sizeof(m_line_time_buffer), ":%d: ", line);
     snprintf(&m_write_buffer[strlen(m_write_buffer)], FULL_LOG_MAX_LENGTH-strlen(m_write_buffer), ":%d: ", line);
 
     // log message

--- a/logging/src/logging.c
+++ b/logging/src/logging.c
@@ -149,14 +149,15 @@ void logging_log_line(logging_level_t level, const char* file, int line, const c
     log_line_helper(level, file, line, module_prefix, fmt, args);
 }
 
-void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) {
+bool logging_level_is_active(logging_logger_t* logger, logging_level_t level) {
     const logging_level_t min_level = logger->level == LOGGING_LEVEL_DEFAULT ? m_init.default_level : logger->level;
-    if (level < min_level) {
-        return;
-    }
+    return level >= min_level;
+}
+
+void logging_log_impl(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    log_line_helper(level, file, line, logger->module_prefix, fmt, args);
+    log_line_helper(level, file, line, module_prefix, fmt, args);
     va_end(args);
 }
 

--- a/logging/src/logging.c
+++ b/logging/src/logging.c
@@ -105,6 +105,7 @@ void logging_log_impl(logging_logger_t* logger, logging_level_t level, const cha
     if (m_init.lock_function) {
         m_init.lock_function(true);
     }
+    m_write_buffer[0] = '\0';
 
     // time
     if (m_init.time_ms_function) {

--- a/logging/src/logging.c
+++ b/logging/src/logging.c
@@ -13,13 +13,6 @@
 #define FILE_NAME_LENGTH        32
 #define FULL_LOG_MAX_LENGTH     (LOGGING_MAX_MSG_LENGTH + LEVEL_PREFIX_LENGTH + TIME_LENGTH + FILE_NAME_LENGTH + 1)
 
-#define GET_IMPL(LOGGER) ((logger_impl_t*)LOGGER->_private)
-
-typedef struct {
-    logging_level_t level;
-} logger_impl_t;
-_Static_assert(sizeof(logger_impl_t) == sizeof(((logging_logger_t*)0)->_private), "Invalid context size");
-
 #if LOGGING_USE_DATETIME
 typedef struct {
     uint16_t year;
@@ -104,8 +97,7 @@ bool logging_init(const logging_init_t* init) {
 }
 
 void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) {
-    logger_impl_t* impl = GET_IMPL(logger);
-    const logging_level_t min_level = impl->level == LOGGING_LEVEL_DEFAULT ? m_init.default_level : impl->level;
+    const logging_level_t min_level = logger->level == LOGGING_LEVEL_DEFAULT ? m_init.default_level : logger->level;
     if (level < min_level) {
         return;
     }
@@ -168,8 +160,4 @@ void logging_log_impl(logging_logger_t* logger, logging_level_t level, const cha
     if (m_init.lock_function) {
         m_init.lock_function(false);
     }
-}
-
-void logging_set_level_impl(logging_logger_t* logger, logging_level_t level) {
-    GET_IMPL(logger)->level = level;
 }

--- a/logging/src/logging.c
+++ b/logging/src/logging.c
@@ -14,44 +14,16 @@
 #define FULL_LOG_MAX_LENGTH     (LOGGING_MAX_MSG_LENGTH + LEVEL_PREFIX_LENGTH + TIME_LENGTH + FILE_NAME_LENGTH + 1)
 
 #define BUFFER_PRINTF(BUFFER, SIZE, FMT, ...) ({ \
-        const size_t _len = strlen(BUFFER); \
+        const uint32_t _len = strlen(BUFFER); \
         snprintf(&BUFFER[_len], (SIZE)-_len, FMT, __VA_ARGS__); \
     })
 
 #define BUFFER_VA_PRINTF(BUFFER, SIZE, FMT, ARGS) ({ \
-        const size_t _len = strlen(BUFFER); \
+        const uint32_t _len = strlen(BUFFER); \
         vsnprintf(&BUFFER[_len], (SIZE)-_len, FMT, ARGS); \
     })
 
 #define BUFFER_WRITE(BUFFER, SIZE, STR) BUFFER_PRINTF(BUFFER, SIZE, "%s", STR)
-
-typedef struct {
-    logging_level_t level;
-    const char* file;
-    int line;
-    const char* module_prefix;
-    logging_timestamp_t timestamp;
-    const char* fmt;
-    va_list args;
-} logging_line_t;
-
-typedef struct {
-    uint8_t hour;
-    uint8_t minute;
-    uint8_t second;
-    uint16_t ms;
-} log_time_t;
-
-#if LOGGING_USE_DATETIME
-typedef struct {
-    struct {
-        uint16_t year;
-        uint8_t month;
-        uint8_t day;
-    } date;
-    log_time_t time;
-} log_datetime_t;
-#endif
 
 static const char* const LEVEL_PREFIX[] = {
     [LOGGING_LEVEL_DEFAULT] =   "????? ", // should never be printed
@@ -66,14 +38,14 @@ static const uint8_t DAYS_PER_MONTH[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31,
 
 static logging_init_t m_init;
 
-static void timestamp_to_time(logging_timestamp_t timestamp, log_time_t* time) {
-    time->ms = timestamp % 1000;
+static void get_time_components(logging_timestamp_t timestamp, logging_timestamp_components_t* components) {
+    components->ms = timestamp % 1000;
     timestamp /= 1000;
-    time->second = timestamp % 60;
+    components->second = timestamp % 60;
     timestamp /= 60;
-    time->minute = timestamp % 60;
+    components->minute = timestamp % 60;
     timestamp /= 60;
-    time->hour = timestamp;
+    components->hour = timestamp;
 }
 
 #if LOGGING_USE_DATETIME
@@ -82,20 +54,20 @@ static bool is_leap_year(uint16_t year) {
     return ((year & 3) == 0 && (year % 100)) || (year % 400) == 0;
 }
 
-static void timestamp_to_datetime(logging_timestamp_t ms, log_datetime_t* datetime) {
+static void get_datetime_components(logging_timestamp_t ms, logging_timestamp_components_t* components) {
     // Calculate the time portion
-    timestamp_to_time(ms % 86400000, &datetime->time);
+    get_time_components(ms % 86400000, components);
 
     // Calculate days since epoch (add 1 for the current day)
     uint32_t days = ms / 86400000 + 1;
 
     // Calculate the year
     uint16_t days_in_year = 365;
-    datetime->date.year = 1970;
+    components->year = 1970;
     while (days > days_in_year) {
         days -= days_in_year;
-        datetime->date.year++;
-        if (is_leap_year(datetime->date.year)) {
+        components->year++;
+        if (is_leap_year(components->year)) {
             // this is a leap year
             days_in_year = 366;
         } else {
@@ -104,35 +76,98 @@ static void timestamp_to_datetime(logging_timestamp_t ms, log_datetime_t* dateti
     }
 
     // Calculate the month and day
-    datetime->date.month = 0;
+    components->month = 0;
     for (uint8_t month = 1; month <= 12; month++) {
-        const uint8_t days_in_month = (month == 2 && is_leap_year(datetime->date.year)) ? 29 : DAYS_PER_MONTH[month-1];
+        const uint8_t days_in_month = (month == 2 && is_leap_year(components->year)) ? 29 : DAYS_PER_MONTH[month-1];
         if (days <= days_in_month) {
-            datetime->date.month = month;
+            components->month = month;
             break;
         } else {
             days -= days_in_month;
         }
     }
-    datetime->date.day = days;
+    components->day = days;
 }
 #endif
 
-static void format_log_line(const logging_line_t* log_line, char* buffer, size_t size) {
+#if !LOGGING_CUSTOM_HANDLER
+static void handle_log_line(const logging_line_t* log_line) {
+    if (m_init.lock_function) {
+        m_init.lock_function(true);
+    }
+    static char buffer[FULL_LOG_MAX_LENGTH];
+    logging_format_line(log_line, buffer, sizeof(buffer));
+    m_init.write_function(buffer);
+    if (m_init.lock_function) {
+        m_init.lock_function(false);
+    }
+}
+#endif
+
+static void log_line_helper(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args) {
+    logging_line_t log_line = {
+        .level = level,
+        .file = file,
+        .line = line,
+        .module_prefix = module_prefix,
+        .timestamp = m_init.time_ms_function ? m_init.time_ms_function() : 0,
+        .fmt = fmt,
+        .args = args,
+    };
+#if LOGGING_USE_DATETIME
+    get_datetime_components(log_line.timestamp, &log_line.timestamp_components);
+#else
+    get_time_components(log_line.timestamp, &log_line.timestamp_components);
+#endif
+
+#if LOGGING_CUSTOM_HANDLER
+    m_init.handler(&log_line);
+#else
+    handle_log_line(&log_line);
+#endif
+}
+
+bool logging_init(const logging_init_t* init) {
+    if (init->default_level == LOGGING_LEVEL_DEFAULT) {
+        return false;
+    }
+#if LOGGING_CUSTOM_HANDLER
+    if (!init->handler) {
+        return false;
+    }
+#else
+    if (!init->write_function) {
+        return false;
+    }
+#endif
+    m_init = *init;
+    return true;
+}
+
+void logging_log_line(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args) {
+    if (level < m_init.default_level) {
+        return;
+    }
+    log_line_helper(level, file, line, module_prefix, fmt, args);
+}
+
+void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) {
+    const logging_level_t min_level = logger->level == LOGGING_LEVEL_DEFAULT ? m_init.default_level : logger->level;
+    if (level < min_level) {
+        return;
+    }
+    va_list args;
+    va_start(args, fmt);
+    log_line_helper(level, file, line, logger->module_prefix, fmt, args);
+    va_end(args);
+}
+
+void logging_format_line(const logging_line_t* log_line, char* buffer, uint32_t size) {
     buffer[0] = '\0';
 
-    // time
-    if (log_line->timestamp) {
-#if LOGGING_USE_DATETIME
-        log_datetime_t datetime;
-        timestamp_to_datetime(log_line->timestamp, &datetime);
-        BUFFER_PRINTF(buffer, size, "%04u-%02u-%02u %02u:%02u:%02u.%03u ", datetime.date.year, datetime.date.month,
-            datetime.date.day, datetime.time.hour, datetime.time.minute, datetime.time.second, datetime.time.ms);
-#else
-        log_time_t time;
-        timestamp_to_time(log_line->timestamp, &time);
-        BUFFER_PRINTF(buffer, size, "%3u:%02u:%02u.%03u ", time.hour, time.minute, time.second, time.ms);
-#endif
+    // Add the timestamp
+    if (m_init.time_ms_function || log_line->timestamp) {
+        BUFFER_PRINTF(buffer, size, LOGGING_TIMESTAMP_FMT_STR " ", LOGGING_TIMESTAMP_FMT_ARGS(log_line->timestamp_components));
     }
 
     // Add the level
@@ -158,60 +193,4 @@ static void format_log_line(const logging_line_t* log_line, char* buffer, size_t
         buffer[size-2] = '\0';
     }
     BUFFER_WRITE(buffer, size, "\n");
-}
-
-static void handle_log_line(const logging_line_t* log_line) {
-    static char buffer[FULL_LOG_MAX_LENGTH];
-    format_log_line(log_line, buffer, sizeof(buffer));
-    if (m_init.write_function) {
-        m_init.write_function(buffer);
-    }
-    if (m_init.raw_write_function) {
-        m_init.raw_write_function(log_line->level, log_line->module_prefix, buffer);
-    }
-}
-
-static void log_line_helper(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args) {
-    if (m_init.lock_function) {
-        m_init.lock_function(true);
-    }
-    const logging_line_t log_line = {
-        .level = level,
-        .file = file,
-        .line = line,
-        .module_prefix = module_prefix,
-        .timestamp = m_init.time_ms_function ? m_init.time_ms_function() : 0,
-        .fmt = fmt,
-        .args = args,
-    };
-    handle_log_line(&log_line);
-    if (m_init.lock_function) {
-        m_init.lock_function(false);
-    }
-}
-
-bool logging_init(const logging_init_t* init) {
-    if ((!init->write_function && !init->raw_write_function) || init->default_level == LOGGING_LEVEL_DEFAULT) {
-        return false;
-    }
-    m_init = *init;
-    return true;
-}
-
-void logging_log_line(logging_level_t level, const char* file, int line, const char* module_prefix, const char* fmt, va_list args) {
-    if (level < m_init.default_level) {
-        return;
-    }
-    log_line_helper(level, file, line, module_prefix, fmt, args);
-}
-
-void logging_log_impl(logging_logger_t* logger, logging_level_t level, const char* file, int line, const char* fmt, ...) {
-    const logging_level_t min_level = logger->level == LOGGING_LEVEL_DEFAULT ? m_init.default_level : logger->level;
-    if (level < min_level) {
-        return;
-    }
-    va_list args;
-    va_start(args, fmt);
-    log_line_helper(level, file, line, logger->module_prefix, fmt, args);
-    va_end(args);
 }

--- a/sonar/tests/main.cpp
+++ b/sonar/tests/main.cpp
@@ -18,7 +18,6 @@ static uint32_t logging_time_ms_function(void) {
 int main(int argc, char **argv) {
   const logging_init_t init_logging = {
     .write_function = logging_write_function,
-    .raw_write_function = nullptr,
     .lock_function = nullptr,
     .time_ms_function = logging_time_ms_function,
     .default_level = LOGGING_LEVEL_DEBUG,


### PR DESCRIPTION
Following debugging a test failure of my project which uses Anchor Console, I found that `console_init()` does not de-register registered commands.

This causes tests harnesses of code using console, designed to use the setup function to re-initialize everything to ensure test independence, to fail if the code tries to ensure that `console_command_register()` succeeds by returning `true`.

The proposed solution is to ensure that `console_init()` wipes the `m_commands` array when called.